### PR TITLE
szip: Fix application name and crates.io links

### DIFF
--- a/szip/Cargo.toml
+++ b/szip/Cargo.toml
@@ -6,8 +6,8 @@ description = """
 A fast command line tool for snappy compression and decompression.
 """
 documentation = "https://docs.rs/snap"
-homepage = "https://github.com/BurntSushi/snap"
-repository = "https://github.com/BurntSushi/snap"
+homepage = "https://github.com/BurntSushi/rust-snappy"
+repository = "https://github.com/BurntSushi/rust-snappy"
 keywords = ["snappy", "compress", "compression", "decompress", "decompression"]
 license = "BSD-3-Clause"
 

--- a/szip/src/main.rs
+++ b/szip/src/main.rs
@@ -29,9 +29,9 @@ Note that this requires reading the entire input/output into memory. In
 general, you shouldn't use this flag unless you have a specific need to.
 
 Usage:
-    snappy [options] [<file> ...]
-    snappy --help
-    snappy --version
+    szip [options] [<file> ...]
+    szip --help
+    szip --version
 
 Options:
     -d, --decompress   Decompress files (default is compression).


### PR DESCRIPTION
I think these were missed in a earlier rename, and I keep noticing them, so I figure I should submit a PR which fixes them. :-)

Thank you once again for all your excellent Rust tools!