### PR TITLE
Remove unnecessary mut

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -499,7 +499,7 @@ impl Encoder {
         // instead of putting a bigger one on the heap. This particular
         // optimization is important if the caller is using Snappy to compress
         // many small blocks. (The memset savings alone is considerable.)
-        let mut table: &mut [u16] =
+        let table: &mut [u16] =
             if table_size <= SMALL_TABLE_SIZE {
                 &mut self.small[0..table_size]
             } else {


### PR DESCRIPTION
This fixes a warning when building with nighty rust:

    warning: variable does not need to be mutable
        --> src/compress.rs:502:13
        |
    502 |         let mut table: &mut [u16] =
        |             ^^^^^^^^^
        |
        = note: #[warn(unused_mut)] on by default