### PR TITLE
Fix out of bounds write

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -168,6 +168,27 @@ fn small_regular() {
     }
 }
 
+// Test that triggered an out of bounds write.
+#[test]
+fn decompress_copy_close_to_end_1() {
+    let buf = [27,
+               0b000010_00, 1, 2, 3,
+               0b000_000_10, 3, 0,
+               0b010110_00, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 ,21, 22, 23, 24, 25, 26];
+    let decompressed = [1, 2, 3, 1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26];
+    assert_eq!(decompressed, &*depress(&buf));
+}
+
+#[test]
+fn decompress_copy_close_to_end_2() {
+    let buf = [28,
+               0b000010_00, 1, 2, 3,
+               0b000_000_10, 3, 0,
+               0b010111_00, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 ,21, 22, 23, 24, 25, 26, 27];
+    let decompressed = [1, 2, 3, 1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27];
+    assert_eq!(decompressed, &*depress(&buf));
+}
+
 // Tests decompression on malformed data.
 
 // An empty buffer.


### PR DESCRIPTION
This fixes issue #12.

In read_copy(), when copying data when the pointers still may overlap,
the worst case scenario is when the diff is 3. To see this, the
following copies will be made:

    [-3, 12] -> [0, 15]
    [-3, 12] -> [3, 18]
    [-3, 12] -> [9, 24]

That is, the copy may write 24 bytes past the current position.
Adjust the check to only enter the if-statement if there are 24 or
more bytes available. Also, update comments to reflect this, add
a debug_assert which verifies that no writes outside the buffer occur.

Two tests are added. One test that illustrates the problem before this
change, and one test case that triggers the code path after this change.

This may in some cases cause more slow copies byte by byte. No noticable
slowdown was noticed when running bench with and without this change.

For reference, the size of how much past the end the slow overlaps
may write for different pointer diffs are shown below. Only diffs
up to 15 are show, since if the diff is 16, this code will not be
run. Note that before this change, the condition was conservative
in the sense that when the diff was 1, the worst case is actually 22,
and not 23.

    Pointer diff: 1
       [-1, 14] -> [0, 15]
       [-1, 14] -> [1, 16]
       [-1, 14] -> [3, 18]
       [-1, 14] -> [7, 22]

    Pointer diff: 2
       [-2, 13] -> [0, 15]
       [-2, 13] -> [2, 17]
       [-2, 13] -> [6, 21]

    Pointer diff: 3
       [-3, 12] -> [0, 15]
       [-3, 12] -> [3, 18]
       [-3, 12] -> [9, 24]

    Pointer diff: 4
       [-4, 11] -> [0, 15]
       [-4, 11] -> [4, 19]

    Pointer diff: 5
       [-5, 10] -> [0, 15]
       [-5, 10] -> [5, 20]

    Pointer diff: 6
       [-6, 9] -> [0, 15]
       [-6, 9] -> [6, 21]

    Pointer diff: 7
       [-7, 8] -> [0, 15]
       [-7, 8] -> [7, 22]

    Pointer diff: 8
       [-8, 7] -> [0, 15]

    Pointer diff: 9
       [-9, 6] -> [0, 15]

    Pointer diff: 10
       [-10, 5] -> [0, 15]

    Pointer diff: 11
       [-11, 4] -> [0, 15]

    Pointer diff: 12
       [-12, 3] -> [0, 15]

    Pointer diff: 13
       [-13, 2] -> [0, 15]

    Pointer diff: 14
       [-14, 1] -> [0, 15]

    Pointer diff: 15
       [-15, 0] -> [0, 15]