### PR TITLE
Fix panic in FrameDecoder

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -153,9 +153,8 @@ pub enum Error {
         /// The chunk type byte that was read.
         byte: u8,
     },
-    /// This error occurs when trying to read a chunk with length greater than
-    /// that supported by this library when reading a Snappy frame formatted
-    /// stream.
+    /// This error occurs when trying to read a chunk with an unexpected or
+    /// incorrect length when reading a Snappy frame formatted stream.
     /// This error only occurs when reading a Snappy frame formatted stream.
     UnsupportedChunkLength {
         /// The length of the chunk encountered.

--- a/src/read.rs
+++ b/src/read.rs
@@ -166,6 +166,12 @@ impl<R: io::Read> io::Read for FrameDecoder<R> {
                     }
                 }
                 Ok(ChunkType::Uncompressed) => {
+                    if len < 4 {
+                        fail!(Error::UnsupportedChunkLength {
+                            len: len as u64,
+                            header: false,
+                        });
+                    }
                     let expected_sum = bytes::io_read_u32_le(&mut self.r)?;
                     let n = len - 4;
                     if n > self.dst.len() {
@@ -187,6 +193,12 @@ impl<R: io::Read> io::Read for FrameDecoder<R> {
                     self.dste = n;
                 }
                 Ok(ChunkType::Compressed) => {
+                    if len < 4 {
+                        fail!(Error::UnsupportedChunkLength {
+                            len: len as u64,
+                            header: false,
+                        });
+                    }
                     let expected_sum = bytes::io_read_u32_le(&mut self.r)?;
                     let sn = len - 4;
                     if sn > self.src.len() {


### PR DESCRIPTION
Fixes #29 

Returns an `UnsupportedChunkLength` error if `len < 4` as suggested. 

Also modifies the docs on the `UnsupportedChunkLength` error variant to be more generic.

