### PR TITLE
Remove trailing semicolon from fail! macro

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -100,7 +100,7 @@ impl<R: io::Read> io::Read for FrameDecoder<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         macro_rules! fail {
             ($err:expr) => {
-                return Err(io::Error::from($err));
+                return Err(io::Error::from($err))
             };
         }
         loop {


### PR DESCRIPTION
If the semicolon_in_expressions_from_macros lint is ever turned into a
hard error, your crate will stop compiling. This commit ensures that
your crate will compile on both current and future versions of Rust.

See rust-lang/rust#79813 for more details